### PR TITLE
Fixed wiki_clean

### DIFF
--- a/corpus/wiki_clean.py
+++ b/corpus/wiki_clean.py
@@ -107,6 +107,8 @@ for line in tqdm(cleaned_lines):
     clean_size += len(line)
 
 print("Writing ...")
+if not os.path.exists("clean"):
+    os.makedirs("clean")
 clean_file = os.path.join("clean","wiki.txt")
 with open(clean_file,"w", encoding="utf8") as clean_f:
     for line in lines:


### PR DESCRIPTION
In wiki_clean, folder 'clean' is not created if it does not exist.